### PR TITLE
Migrate from bsddb3 to berkeleydb

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,12 +9,11 @@
 * Install python 3.6+
 * Install `requirements.py` by running:
   * `$pip install -r requirements.txt`
-* Your wallet must be **UNENCRYPTED**!
+* Your wallet must be __UNENCRYPTED__!
 
 ## Installation
 
 <!-- - Install the `bsddb3` module (if you're on Windows, use Gohlke's site). -->
-
 
 -----------------------------------------------------------
 
@@ -31,6 +30,7 @@ default location:
 * TODO: Add default location
 
 -----------------------------------------------------------
+
 ### Types / CoinType
 
 * For Bitcoin, run `python3 main.py -d wallet.dat -v 0`

--- a/README.md
+++ b/README.md
@@ -13,28 +13,47 @@
 
 ## Installation
 
-<!-- - Install the `bsddb3` module (if you're on Windows, use Gohlke's site). -->
+### _Linux - Install BerkeleyDB_
 
------------------------------------------------------------
+#### [Berkeley source installation](https://www.linuxfromscratch.org/blfs/view/svn/server/db.html)
 
-## Wallet location on different OS's
+1. [Download Berkely to compile](https://anduin.linuxfromscratch.org/BLFS/bdb/db-5.3.28.tar.gz)
+
+2. First apply a fix so that this will compile with current versions of g++:
+
+    `$ sed -i 's/\(__atomic_compare_exchange\)/\1_db/' src/dbinc/atomic.h`
+
+3. Install Berkeley DB by running the following commands:
+
+    `cd build_unix                        &&
+    ../dist/configure --prefix=/usr      \
+                      --enable-compat185 \
+                      --enable-dbm       \
+                      --disable-static   \
+                      --enable-cxx       &&
+    make`
+
+4. Now, as the __root__ user:
+
+    `make docdir=/usr/share/doc/db-5.3.28 install &&
+        chown -v -R root:root                        \
+              /usr/bin/db_*                          \
+              /usr/include/db{,_185,_cxx}.h          \
+              /usr/lib/libdb*.{so,la}                \
+              /usr/share/doc/db-5.3.28`
+
+## Wallet location
 
 ### _Linux_
 
 * `~/.bitcoin/wallets/[WALLET_NAME]/wallet.dat`
 
-### _Windows_
-
-default location:  
-
-* TODO: Add default location
-
 -----------------------------------------------------------
 
 ### Types / CoinType
 
-* For Bitcoin, run `python3 main.py -d wallet.dat -v 0`
-* For Litecoin, run `python3 main.py -d wallet.dat -v 48`
+* For Bitcoin, run `python3 main.py -d WALLET_NAME.dat -v 0`
+* For Litecoin, run `python3 main.py -d WALLET_NAME.dat -v 48`
 
 -----------------------------------------------------------
 

--- a/README.md
+++ b/README.md
@@ -1,19 +1,49 @@
-walletool ~ a tool for reading wallet.dat files
-===============================================
+# Walletool - Read wallet.dat files
 
-Installation
-------------
+## Access [Bitcoin-Core](https://bitcoin.org/en/bitcoin-core/) and [Litecoin-Core](https://litecoin.org/) wallets __addresses__ and __private keys__
 
-* Install Python 3.x.
-* Install the `bsddb3` module (if you're on Windows, use Gohlke's site).
-
-Extracting private keys from Bitcoin-QT/Litecoin-QT wallets
 -----------------------------------------------------------
 
-* Have your `wallet.dat` handy.
-* For Bitcoin, run `python wt_extract_keys.py -d wallet.dat -v 0`
-* For Litecoin, run `python wt_extract_keys.py -d wallet.dat -v 48`
+## Requirements
 
-A list of addresses / private keys is printed.
+* Install python 3.6+
+* Install `requirements.py` by running:
+  * `$pip install -r requirements.txt`
+* Your wallet must be **UNENCRYPTED**!
 
-YMMV :)
+## Installation
+
+<!-- - Install the `bsddb3` module (if you're on Windows, use Gohlke's site). -->
+
+
+-----------------------------------------------------------
+
+## Wallet location on different OS's
+
+### _Linux_
+
+* `~/.bitcoin/wallets/[WALLET_NAME]/wallet.dat`
+
+### _Windows_
+
+default location:  
+
+* TODO: Add default location
+
+-----------------------------------------------------------
+### Types / CoinType
+
+* For Bitcoin, run `python3 main.py -d wallet.dat -v 0`
+* For Litecoin, run `python3 main.py -d wallet.dat -v 48`
+
+-----------------------------------------------------------
+
+### _Output_
+
+Print / Log - Wallet addresses and private keys
+
+<!-- Install berkely DB
+https://www.linuxfromscratch.org/blfs/view/svn/server/db.html
+
+Alt: 
+  `$ sudo apt install libdb-dev && pip install bsddb3` -->

--- a/check_bchain.py
+++ b/check_bchain.py
@@ -5,6 +5,7 @@ import argparse
 
 var_re = re.compile('var (.+?) = (.+?);')
 
+
 def main():
     ap = argparse.ArgumentParser()
     ap.add_argument('file', help='address file; one address per line')
@@ -29,6 +30,7 @@ def main():
         if args.ignore_no_tx and vs['total_tx'] == 0:
             continue
         print(vs)
+
 
 if __name__ == '__main__':
     main()

--- a/check_dogechain.py
+++ b/check_dogechain.py
@@ -4,6 +4,7 @@ import requests
 import sys
 import time
 
+
 def main():
     ap = argparse.ArgumentParser()
     ap.add_argument('file', help='address file; one address per line')
@@ -12,7 +13,8 @@ def main():
     for line in open(args.file):
         line = line.strip()
         while True:
-            r = requests.get('https://dogechain.info/api/v1/address/balance/%s' % line)
+            r = requests.get(
+                'https://dogechain.info/api/v1/address/balance/%s' % line)
             if r.status_code == 429:  # Too Many Requests
                 print('Throttled, hold on...', file=sys.stderr)
                 time.sleep(60)
@@ -25,6 +27,7 @@ def main():
         r['addr'] = line
         print(r)
         time.sleep(0.5)
+
 
 if __name__ == '__main__':
     main()

--- a/main.py
+++ b/main.py
@@ -25,9 +25,9 @@ def main():
         version = addressTypes[args.type]
 
     # Start reading wallet information
-    w_data = read_wallet_dat(args.wallet)
+    wallet_data = read_wallet_dat(args.wallet)
     addr_tuples = []
-    for item in parse_wallet_dict(w_data):
+    for item in parse_wallet_dict(wallet_data):
         if isinstance(item, KeyWalletItem):
             address = item.get_address(version=coinType)
             privkey = item.get_private_key(version=coinType)

--- a/main.py
+++ b/main.py
@@ -1,24 +1,24 @@
 import argparse
 from walletool.wallet_files import read_wallet_dat
 from walletool.wallet_items import parse_wallet_dict, KeyWalletItem
-from walletool.consts import addrtypes
+from walletool.consts import addressTypes
 
 
 def main():
     ap = argparse.ArgumentParser()
     ap.add_argument('-d', '--dat', help='wallet.dat path',
                     required=True, dest='filename')
-    ap.add_argument('-v', '--version',
-                    help='address version, as integer, 0xHEX, or any of the following known coins:\n[%s]' % ', '.join(sorted(addrtypes)), required=True)
+    ap.add_argument('-t', '--type',
+                    help='address version, as integer, 0xHEX, or any of the following known coins:\n[%s]' % ', '.join(sorted(addressTypes)), required=True)
     args = ap.parse_args()
     if args.version.startswith('0x'):
         version = int(args.version[2:], 16)
     elif args.version.isdigit():
         version = int(args.version)
     else:
-        if args.version not in addrtypes:
-            raise ValueError('invalid version (see --help)')
-        version = addrtypes[args.version]
+        if args.version not in addressTypes:
+            raise ValueError('invalid type (see --help)')
+        version = addressTypes[args.version]
     w_data = read_wallet_dat(args.filename)
     addr_tuples = []
     for item in parse_wallet_dict(w_data):

--- a/main.py
+++ b/main.py
@@ -5,29 +5,43 @@ from walletool.consts import addressTypes
 
 
 def main():
+    
+    # Parser Arguments
     ap = argparse.ArgumentParser()
     ap.add_argument('-d', '--dat', help='wallet.dat path',
                     required=True, dest='filename')
     ap.add_argument('-t', '--type',
                     help='address version, as integer, 0xHEX, or any of the following known coins:\n[%s]' % ', '.join(sorted(addressTypes)), required=True)
     args = ap.parse_args()
+    
+    # Parser Logic - Checking for hex
     if args.type.startswith('0x'):
-        version = int(args.type[2:], 16)
-    elif args.type.isdigit():
-        version = int(args.type)
+        coinType = int(args.type[2:], 16)
+    elif args.type.isdigit(): ## Else: Use set addressTypes
+        coinType = int(args.type)
     else:
         if args.type not in addressTypes:
             raise ValueError('invalid type (see --help)')
         version = addressTypes[args.type]
+        
+    # Start reading wallet information
     w_data = read_wallet_dat(args.filename)
     addr_tuples = []
     for item in parse_wallet_dict(w_data):
         if isinstance(item, KeyWalletItem):
-            address = item.get_address(version=version)
-            privkey = item.get_private_key(version=version)
+            address = item.get_address(version=coinType)
+            privkey = item.get_private_key(version=coinType)
             addr_tuples.append((address, privkey))
     for address, privkey in addr_tuples:
         print(address, privkey)
+        # log = input("Save log of Output? (Y/n): ")
+        # if (log.lower() == "n"):
+        #     print(f'Address: \n{address} \n*2 Private-key: \n{privkey}')
+        # else:
+        #     file_output = open('wallet-output.txt', "w")
+        #     file_output.write()
+        #     print(f'Address: \n{address} \n*2 Private-key: \n{privkey}')
+        #     print()
 
 
 if __name__ == '__main__':

--- a/main.py
+++ b/main.py
@@ -5,27 +5,27 @@ from walletool.consts import addressTypes
 
 
 def main():
-    
+
     # Parser Arguments
     ap = argparse.ArgumentParser()
     ap.add_argument('-d', '--dat', help='wallet.dat path',
-                    required=True, dest='filename')
+                    required=True, dest='wallet')
     ap.add_argument('-t', '--type',
                     help='address version, as integer, 0xHEX, or any of the following known coins:\n[%s]' % ', '.join(sorted(addressTypes)), required=True)
     args = ap.parse_args()
-    
+
     # Parser Logic - Checking for hex
     if args.type.startswith('0x'):
         coinType = int(args.type[2:], 16)
-    elif args.type.isdigit(): ## Else: Use set addressTypes
+    elif args.type.isdigit():  # Else: Use set addressTypes
         coinType = int(args.type)
     else:
         if args.type not in addressTypes:
             raise ValueError('invalid type (see --help)')
         version = addressTypes[args.type]
-        
+
     # Start reading wallet information
-    w_data = read_wallet_dat(args.filename)
+    w_data = read_wallet_dat(args.wallet)
     addr_tuples = []
     for item in parse_wallet_dict(w_data):
         if isinstance(item, KeyWalletItem):

--- a/main.py
+++ b/main.py
@@ -11,14 +11,14 @@ def main():
     ap.add_argument('-t', '--type',
                     help='address version, as integer, 0xHEX, or any of the following known coins:\n[%s]' % ', '.join(sorted(addressTypes)), required=True)
     args = ap.parse_args()
-    if args.version.startswith('0x'):
-        version = int(args.version[2:], 16)
-    elif args.version.isdigit():
-        version = int(args.version)
+    if args.type.startswith('0x'):
+        version = int(args.type[2:], 16)
+    elif args.type.isdigit():
+        version = int(args.type)
     else:
-        if args.version not in addressTypes:
+        if args.type not in addressTypes:
             raise ValueError('invalid type (see --help)')
-        version = addressTypes[args.version]
+        version = addressTypes[args.type]
     w_data = read_wallet_dat(args.filename)
     addr_tuples = []
     for item in parse_wallet_dict(w_data):

--- a/main.py
+++ b/main.py
@@ -26,22 +26,28 @@ def main():
 
     # Start reading wallet information
     wallet_data = read_wallet_dat(args.wallet)
-    addr_tuples = []
+    addr_list = ['', '']
     for item in parse_wallet_dict(wallet_data):
         if isinstance(item, KeyWalletItem):
             address = item.get_address(version=coinType)
             privkey = item.get_private_key(version=coinType)
-            addr_tuples.append((address, privkey))
-    for address, privkey in addr_tuples:
-        print(address, privkey)
-        # log = input("Save log of Output? (Y/n): ")
-        # if (log.lower() == "n"):
-        #     print(f'Address: \n{address} \n*2 Private-key: \n{privkey}')
-        # else:
-        #     file_output = open('wallet-output.txt', "w")
-        #     file_output.write()
-        #     print(f'Address: \n{address} \n*2 Private-key: \n{privkey}')
-        #     print()
+            addr_list[0] += address
+            addr_list[1] += privkey
+    
+    # Log address and private key
+    log = input("Save log of Output? (Y/n): ")
+    if (log.lower() == "n"):
+        print(f'\nAddress:\n{addr_list[0]} \n\nPrivate-Key: \n{addr_list[1]}')
+    elif (log.lower() == "y"):
+        file_output = open('wallet-output.txt', "w")
+        file_output.write(f'Address:\n{addr_list[0]} \n\nPrivate-Key: \n{addr_list[1]}')
+        print(f'\nAddress:\n{addr_list[0]} \n\nPrivate-Key: \n{addr_list[1]}')
+        print('\n>> Output saved as {wallet-output.txt}. <<')
+    else:
+        file_output = open('wallet-output.txt', "w")
+        file_output.write(f'Address:\n{addr_list[0]} \n\nPrivate-Key: \n{addr_list[1]}')
+        print('\n>> Output saved as {wallet-output.txt}. <<')
+            
 
 
 if __name__ == '__main__':

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+berkeleydb==18.1.5
+requests==2.27.1

--- a/walletool/bc_data_stream.py
+++ b/walletool/bc_data_stream.py
@@ -1,11 +1,10 @@
 # -- encoding: UTF-8 --
+import struct
 import sys
 
 assert sys.version_info[0] == 3  # TODO: Use six for 2/3 compat
 
 # From Joric's pywallet.
-
-import struct
 
 
 class SerializationError(Exception):

--- a/walletool/consts.py
+++ b/walletool/consts.py
@@ -1,4 +1,4 @@
-addrtypes = {
+addressTypes = {
     'bitcoin': 0,
     'litecoin': 48,
     'namecoin': 52,

--- a/walletool/wallet_files.py
+++ b/walletool/wallet_files.py
@@ -4,7 +4,7 @@ import os
 
 
 def read_wallet_dat(filename):
-    from bsddb3 import db
+    from berkeleydb import db
     filename = os.path.realpath(filename)
     env = db.DBEnv()
     env.set_lk_detect(db.DB_LOCK_DEFAULT)

--- a/walletool/wallet_items.py
+++ b/walletool/wallet_items.py
@@ -147,7 +147,8 @@ class WalletItem:
             data.update(parse_BlockLocator(vds))
         elif type == 'ckey':
             data['public_key'] = kds.read_bytes(kds.read_compact_size())
-            data['encrypted_private_key'] = vds.read_bytes(vds.read_compact_size())
+            data['encrypted_private_key'] = vds.read_bytes(
+                vds.read_compact_size())
         elif type == 'mkey':
             data['nID'] = kds.read_uint32()
             data['encrypted_key'] = vds.read_string()

--- a/wt_extract_keys.py
+++ b/wt_extract_keys.py
@@ -3,10 +3,13 @@ from walletool.wallet_files import read_wallet_dat
 from walletool.wallet_items import parse_wallet_dict, KeyWalletItem
 from walletool.consts import addrtypes
 
+
 def main():
     ap = argparse.ArgumentParser()
-    ap.add_argument('-d', '--dat', help='wallet.dat path', required=True, dest='filename')
-    ap.add_argument('-v', '--version', help='address version, as integer, 0xHEX, or any of the following known coins:\n[%s]' % ', '.join(sorted(addrtypes)), required=True)
+    ap.add_argument('-d', '--dat', help='wallet.dat path',
+                    required=True, dest='filename')
+    ap.add_argument('-v', '--version',
+                    help='address version, as integer, 0xHEX, or any of the following known coins:\n[%s]' % ', '.join(sorted(addrtypes)), required=True)
     args = ap.parse_args()
     if args.version.startswith('0x'):
         version = int(args.version[2:], 16)


### PR DESCRIPTION
## Primarily converted the depreciated library bsddb3 to berkelydb

Added:
- Comments in the new, now named `main.py` file.
- Logging-to-file capability for the address and private-key. And to make it easier to copy the address/private-key

Updated:
- Linted the python files.
- Renamed some variables in `main.py`, to make the functions easier to understand.
- The output-ed Address-tuple was changed to a list to update into one long string, and to become easier to work with.